### PR TITLE
Fix exception when package.json doesn't have `dependencies` field

### DIFF
--- a/getConfig.js
+++ b/getConfig.js
@@ -16,10 +16,11 @@ async function getFrameworkConfig() {
     const matches = []
     
     spinner = ora('Looking for matching config').start()
-    
-    const pkgjson = existsSync('package.json')
-        ? require(resolve(process.cwd(), 'package.json'))
-        : { dependencies: {}, devDependencies: {} }
+
+    const pkgjson = { dependencies: {}, devDependencies: {} };
+    if (existsSync('package.json')) {
+        Object.assign(pkgjson, require(resolve(process.cwd(), 'package.json')));
+    }
     Object.assign(pkgjson.dependencies, pkgjson.devDependencies)
 
     const configFiles = readdirSync(resolve(__dirname, 'configs'))    


### PR DESCRIPTION
Fix #2 
Unhandled exception then `package.json` doesn't have the `dependencies` property (dev dependencies only)/