### PR TITLE
fix: remove trailing slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ async function start(options) {
         url.path = url.path
             .replace(/^\/$/, '/index')
             .replace(/^([^#?]+).*$/, '$1')
+            .replace(/\/$/, '')
 
         return url
     }


### PR DESCRIPTION
If there are URLs with a hash on the pages, routes processed twice and output tree is broken:
```
├── index.html
├── kits
│   ├── colony-kit
│   │   └── .html
│   ├── colony-kit.html
│   ├── cyberbug
│   │   └── .html
│   ├── cyberbug.html
│   ├── cyberlight
│   │   └── .html
│   └── cyberlight.html
```

Removing trailing slash fix this for me.
